### PR TITLE
rename of jellybench_py

### DIFF
--- a/Jellyfin.HardwareVisualizer/Client/Shared/UnauthorizedTopBar.razor
+++ b/Jellyfin.HardwareVisualizer/Client/Shared/UnauthorizedTopBar.razor
@@ -13,7 +13,7 @@
 		</NavLink>
 	</div>
 	<div class="nav-item">
-		<NavLink class="nav-link" href="https://github.com/BotBlake/pyTAB/" target="__blank" Match="NavLinkMatch.All">
+		<NavLink class="nav-link" href="https://github.com/BotBlake/jellybench_py/" target="__blank" Match="NavLinkMatch.All">
 			<span class="oi oi-cloud-download" aria-hidden="true"></span> Survey Tool
 		</NavLink>
 	</div>


### PR DESCRIPTION
`pyTAB` has been renamed to `jellybench_py`
Therefore the URL needs to be updated.